### PR TITLE
Correct endianness of serialized double values in compact binary format.

### DIFF
--- a/rpc-spec-compact-protocol.asciidoc
+++ b/rpc-spec-compact-protocol.asciidoc
@@ -54,7 +54,7 @@ Strings are first encoded to UTF-8, and then send as binary.
 === Double encoding
 
 Values of type `double` are first converted to an i64 according to the IEEE 754 floating-point "double format" bit
-layout. Most run-times provide primitives for the conversion. The i64 is encoded using 8 bytes in big endian order.
+layout. Most run-times provide primitives for the conversion. The i64 is encoded using 8 bytes in little endian order.
 
 This is some scala code showing the JVM primitives to convert from double to i64 and back:
 

--- a/rpc-spec-compact-protocol.asciidoc
+++ b/rpc-spec-compact-protocol.asciidoc
@@ -181,19 +181,19 @@ Where:
 
 The short form _should_ be used when the length is in the range 0 - 14 (inclusive).
 
-The following element-types are used (note that these are _different_ from the field-types):
+The following element-types are used (note that, aside from `bool`, these are the same as the field-types):
 
-* `bool`, encoded as `2`
+* `bool`, encoded as `1`
 * `byte`, encoded as `3`
-* `double`, encoded as `4`
-* `i16`, encoded as `6`
-* `i32`, encoded as `8`
-* `i64`, encoded as `10`
-* `string`, used for binary and string fields, encoded as `11`
-* `struct`, used for structs and union fields, encoded as `12`
-* `map`, encoded as `13`
-* `set`, encoded as `14`
-* `list`, encoded as `15`
+* `i16`, encoded as `4`
+* `i32`, encoded as `5`
+* `i64`, encoded as `6`
+* `double`, encoded as `7`
+* `binary`, used for binary and string fields, encoded as `8`
+* `list`, encoded as `9`
+* `set`, encoded as `10`
+* `map`, encoded as `11`
+* `struct`, used for both structs and union fields, encoded as `12`
 
 The maximum list/set size is configurable. By default there is no limit (meaning the limit is the maximum i32 value:
 2147483647).

--- a/rpc-spec-compact-protocol.asciidoc
+++ b/rpc-spec-compact-protocol.asciidoc
@@ -18,9 +18,20 @@ def zigzagToI64(n: Long): Long = (n >>> 1) ^ - (n & 1)
 
 The zigzag int is then encoded as a *var int*. Var ints take 1 to 5 bytes (i32) or 1 to 10 bytes (i64). The most
 significant bit of each byte indicates if more bytes follow. The concatenation of the least significant 7 bits from each
-byte form the number, where the first byte has the most significant bits (so they are in big endian or network order).
+byte form the number, where the first byte has the least significant bits (so they are in little endian order). The
+following table gives some examples of var int encoding.
 
-Var ints are sometimes used directly inside the compact protocol to represent numbers that are usually positive.
+....
+Input    Bytes
+-------  -----
+      0  0
+    127  127
+    128  128 1
+  12345  185 96
+1234567  135 173 75
+....
+
+Var ints are sometimes used directly inside the compact protocol to represent non-negative numbers.
 
 To encode an `i16` as zigzag int, it is first converted to an `i32` and then encoded as such. The type `i8` simply
 uses a single byte as in the binary protocol.


### PR DESCRIPTION
First, let me thank you for the writing this thrift protocol specification. I just wrote a implementation of the compact binary protocol going almost entirely from this document. However, I discovered a small error in the description of the serialization of double values in the compact binary protocol:

Doubles are serialized in little-endian byte order in compact binary
format.  You can verify that by comparing the TCompactProtocol and
TBinaryProtocol classes in the Java implementation.

The compact binary format calls `fixedLongToBytes` to write out the
bytes after the double has been converted a 64-bit long value by
Double.doubleToLongBits:
https://github.com/apache/thrift/blob/master/lib/java/src/org/apache/thrift/protocol/TCompactProtocol.java#L353

The `fixedLongToBytes` writes the bytes in little-endian order:
https://github.com/apache/thrift/blob/0.9.3/lib/java/src/org/apache/thrift/protocol/TCompactProtocol.java#L464

By comparison, the binary format calls `writeI64` to write the bytes,
which writes them in big-endian order:
https://github.com/apache/thrift/blob/0.9.3/lib/java/src/org/apache/thrift/protocol/TBinaryProtocol.java#L194
